### PR TITLE
Fixes issue where android output and preview are different resolutions

### DIFF
--- a/android/src/main/java/com/rectanglescanner/helpers/ImageProcessor.java
+++ b/android/src/main/java/com/rectanglescanner/helpers/ImageProcessor.java
@@ -84,15 +84,14 @@ public class ImageProcessor extends Handler {
     Process a single frame from the camera video
     */
     private void processCapturedImage(Mat picture) {
-
-        Mat img = Imgcodecs.imdecode(picture, Imgcodecs.CV_LOAD_IMAGE_UNCHANGED);
+        Mat capturedImage = Imgcodecs.imdecode(picture, Imgcodecs.CV_LOAD_IMAGE_UNCHANGED);
         picture.release();
 
-        Log.d(TAG, "processCapturedImage - imported image " + img.size().width + "x" + img.size().height);
+        Log.d(TAG, "processCapturedImage - imported image " + capturedImage.size().width + "x" + capturedImage.size().height);
 
-        rotateImageForScreen(img);
+        rotateImageForScreen(capturedImage);
 
-        CapturedImage doc = cropImageToLatestQuadrilateral(img);
+        CapturedImage doc = cropImageToLatestQuadrilateral(capturedImage);
 
         mMainActivity.onProcessedCapturedImage(doc);
         doc.release();
@@ -123,22 +122,20 @@ public class ImageProcessor extends Handler {
     /**
     Crops the image to the latest detected rectangle and fixes perspective
     */
-    private CapturedImage cropImageToLatestQuadrilateral(Mat inputRgba) {
-        ArrayList<MatOfPoint> contours = findContours(inputRgba);
+    private CapturedImage cropImageToLatestQuadrilateral(Mat capturedImage) {
+        CapturedImage sd = new CapturedImage(capturedImage);
 
-        CapturedImage sd = new CapturedImage(inputRgba);
-
-        sd.originalSize = inputRgba.size();
+        sd.originalSize = capturedImage.size();
         sd.heightWithRatio = Double.valueOf(sd.originalSize.width).intValue();
         sd.widthWithRatio = Double.valueOf(sd.originalSize.height).intValue();
 
         Mat doc;
         if (this.lastDetectedRectangle != null) {
-            doc = fourPointTransform(inputRgba, this.lastDetectedRectangle.points);
+            doc = fourPointTransform(capturedImage, this.lastDetectedRectangle.getPointsForSize(capturedImage.size()));
             Core.flip(doc.t(), doc, 0);
         } else {
-            doc = new Mat(inputRgba.size(), CvType.CV_8UC4);
-            inputRgba.copyTo(doc);
+            doc = new Mat(capturedImage.size(), CvType.CV_8UC4);
+            capturedImage.copyTo(doc);
             Core.flip(doc.t(), doc, 0);
         }
         applyFilters(doc);

--- a/android/src/main/java/com/rectanglescanner/helpers/ImageProcessor.java
+++ b/android/src/main/java/com/rectanglescanner/helpers/ImageProcessor.java
@@ -127,7 +127,9 @@ public class ImageProcessor extends Handler {
 
         Mat doc;
         if (this.lastDetectedRectangle != null) {
-            doc = fourPointTransform(capturedImage, this.lastDetectedRectangle.getPointsForSize(capturedImage.size()));
+            Mat croppedCapturedImage = this.lastDetectedRectangle.cropImageToRectangleSize(capturedImage);
+            doc = fourPointTransform(croppedCapturedImage, this.lastDetectedRectangle.getPointsForSize(croppedCapturedImage.size()));
+            croppedCapturedImage.release();
         } else {
             doc = new Mat(capturedImage.size(), CvType.CV_8UC4);
             capturedImage.copyTo(doc);

--- a/android/src/main/java/com/rectanglescanner/helpers/Quadrilateral.java
+++ b/android/src/main/java/com/rectanglescanner/helpers/Quadrilateral.java
@@ -1,6 +1,8 @@
 package com.rectanglescanner.helpers;
 
 import org.opencv.core.MatOfPoint;
+import org.opencv.core.Rect;
+import org.opencv.core.Mat;
 import org.opencv.core.Point;
 import org.opencv.core.Size;
 
@@ -19,6 +21,33 @@ public class Quadrilateral {
         this.contour = contour;
         this.points = points;
         this.sourceSize = sourceSize;
+    }
+
+    /**
+    Crops the edges of the image to the aspect ratio of the detected rectangle.
+    */
+    public Mat cropImageToRectangleSize(Mat image) {
+      Size imageSize = image.size();
+      double rectangleRatio = this.sourceSize.height / this.sourceSize.width;
+      double imageRatio = imageSize.height / imageSize.width;
+
+      double cropHeight = imageSize.height;
+      double cropWidth = imageSize.width;
+      // Used to center the crop in the middle
+      int rectangleXCoord = 0;
+      int rectangleYCoord = 0;
+      if (imageRatio > rectangleRatio) {
+        // Height should be cropped
+        cropHeight = cropWidth * rectangleRatio;
+        rectangleYCoord = (int)((imageSize.height - cropHeight) / 2);
+      } else {
+        // Width should be cropped
+        cropWidth = cropHeight / rectangleRatio;
+        rectangleXCoord = (int)((imageSize.width - cropWidth) / 2);
+      }
+
+      Rect rectCrop = new Rect(rectangleXCoord, rectangleYCoord, (int)cropWidth, (int)cropHeight);
+      return new Mat(image, rectCrop);
     }
 
     /**

--- a/android/src/main/java/com/rectanglescanner/helpers/Quadrilateral.java
+++ b/android/src/main/java/com/rectanglescanner/helpers/Quadrilateral.java
@@ -8,6 +8,7 @@ import android.os.Bundle;
 
 /**
  * Created by Jake on Jan 6, 2020.
+ * Represents the detected rectangle from an image
  */
 public class Quadrilateral {
     public MatOfPoint contour;
@@ -20,6 +21,29 @@ public class Quadrilateral {
         this.sourceSize = sourceSize;
     }
 
+    /**
+    Returns the points of the rectangle scaled to the given size
+    */
+    public Point[] getPointsForSize(Size outputSize) {
+      double scale = outputSize.height / this.sourceSize.height;
+      if (scale == 1) {
+        return this.points;
+      }
+
+      Point[] scaledPoints = new Point[4];
+      for (int i = 0;i < this.points.length;i++ ) {
+        scaledPoints[i] = this.points[i].clone();
+        scaledPoints[i].x *= scale;
+        scaledPoints[i].y *= scale;
+      }
+
+      return scaledPoints;
+    }
+
+
+    /**
+    Returns the rectangle as a bundle object
+    */
     public Bundle toBundle() {
       Bundle quadMap = new Bundle();
 


### PR DESCRIPTION
On Android, scales the detected rectangle coordinates to the output resolution size so the crop and transform is applied correctly. This fixes issues when the preview and captured image resolution sizes are not the same scale.

closes #14 