### PR TITLE
Set AVCaptureSession to start/stop on background thread on iOS

### DIFF
--- a/ios/CameraDeviceController.m
+++ b/ios/CameraDeviceController.m
@@ -146,7 +146,10 @@ Represents the input from the camera device
 - (void)start
 {
     self._isStopped = NO;
-    [self.captureSession startRunning];
+    dispatch_queue_t globalQueue =  dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0);
+    dispatch_async(globalQueue, ^{
+      [self.captureSession startRunning];  
+    });
     [self hidePreviewLayerView:NO completion:nil];
 }
 
@@ -156,7 +159,10 @@ Represents the input from the camera device
 - (void)stop
 {
     self._isStopped = YES;
-    [self.captureSession stopRunning];
+    dispatch_queue_t globalQueue =  dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0);
+    dispatch_async(globalQueue, ^{
+      [self.captureSession stopRunning];  
+    });
     [self hidePreviewLayerView:YES completion:nil];
 }
 


### PR DESCRIPTION
Modified to start and stop the AVCaptureSession on a background thread.

According to official Apple documentation:
> The `startRunning` method is a blocking call which can take some time, therefore you should perform session setup on a serial queue so that the main queue isn't blocked (which keeps the UI responsive).

Similarly, `stopRunning` is also synchronous and blocking.

fixes #24 